### PR TITLE
Add scraped page archive

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -5,11 +5,11 @@
 require 'scraperwiki'
 require 'nokogiri'
 require 'date'
-require 'open-uri'
-
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 def noko(url)
   Nokogiri::HTML(open(url).read, nil, 'utf-8')


### PR DESCRIPTION
Mentioned in issue: https://github.com/everypolitician/everypolitician-data/issues/20544

# Scraper change checklist

* [x] scraper is on Morph.io under the "everypolitician-scrapers" group
* [x] scraper's GitHub "Website" link points at morph.io page
* [x] scraper is set to auto-run
* [x] scraper is archiving
* [ ] ~scraper has webhook set _(usually only set on Wikidata person-data scrapers)_~

## [Adding Archiving to Scraper checklist](https://github.com/everypolitician/everypolitician/wiki/Adding-Archiving-to-Scraper-checklist)
* [x] 1. we are using at least version 0.5 of scraped_page_archive gem?
* [x] 2. scraper uses scraped_page_archive gem directly or via a suitable strategy?
* [ ] 3. MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured?
* [x] 4. pages are being archived in new branch of correct scraper repo? — https://github.com/everypolitician-scrapers/suriname-nationale-assemblee/tree/scraped-pages-archive
